### PR TITLE
Delete split source files

### DIFF
--- a/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace CCVTAC.Console.PostProcessing;
 
 public class Setup
@@ -24,6 +26,14 @@ public class Setup
         Renamer.Run(WorkingDirectory, Printer);
         Deleter.Run(WorkingDirectory, Printer);
         Mover.Run(WorkingDirectory, MoveToDirectory, Printer);
+
+        IReadOnlyList<string> ignoreFiles = new List<string>() { ".DS_Store" };
+        if (Directory.GetFiles(WorkingDirectory, "*")
+                     .Where(dirFile => !ignoreFiles.Any(ignoreFile => dirFile.EndsWith(ignoreFile)))
+                     .Any())
+        {
+            Printer.Warning("Some files unexpectedly remain in the working folder. Please check it.");
+        }
 
         Printer.Print("Post-processing done!");
     }

--- a/CCVTAC/CCVTAC.Console/PostProcessing/Tagger.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Tagger.cs
@@ -80,14 +80,35 @@ internal static class Tagger
                 continue;
             }
 
-            var audioFilesForThisID = Directory.GetFiles(workingDirectory, $"*{idNamePair.Key}*{audioFileExtension}");
+            var audioFilesForThisID = Directory
+                .GetFiles(workingDirectory, $"*{idNamePair.Key}*{audioFileExtension}")
+                .ToList();
             if (!audioFilesForThisID.Any())
             {
                 printer.Error($"No {audioFileExtension} files for ID {idNamePair.Key} were found.");
                 continue;
             }
             printer.Print($"Found {audioFilesForThisID.Count()} audio file(s) for resource ID {idNamePair.Key}");
-            // TODO: If there is more than one, it indicates a split video, so the original (largest) should be deleted.
+
+            // For split videos, delete the source file.
+            if (audioFilesForThisID.Count() > 1)
+            {
+                var largestFileInfo = audioFilesForThisID
+                    .Select(fn => new FileInfo(fn))
+                    .OrderByDescending(fi => fi.Length)
+                    .First();
+
+                try
+                {
+                    File.Delete(largestFileInfo.FullName);
+                    audioFilesForThisID.Remove(largestFileInfo.FullName);
+                    printer.Print($"Deleted original file \"{largestFileInfo.Name}\"");
+                }
+                catch (Exception ex)
+                {
+                    printer.Error($"Error deleting file \"{largestFileInfo.Name}\": {ex.Message}");
+                }
+            }
 
             foreach (var audioFilePath in audioFilesForThisID)
             {

--- a/CCVTAC/CCVTAC.Console/Printer.cs
+++ b/CCVTAC/CCVTAC.Console/Printer.cs
@@ -42,7 +42,7 @@ public class Printer
     public void Warning(string message, byte appendLines = 0)
     {
         // Print("[yellow]" + message + "[/]", true, appendLines: appendLines, processMarkup: true);
-        AnsiConsole.MarkupLineInterpolated($"[yellow]- {message}[/]");
+        AnsiConsole.MarkupLineInterpolated($"[yellow]{message}[/]");
         PrintEmptyLines(appendLines);
     }
 


### PR DESCRIPTION
When a video is split, the original, full-length audio file is saved too as part of the process, but is unnecessary so is deleted.