### PR TITLE
Move orphaned-file warning

### DIFF
--- a/CCVTAC/CCVTAC.Console/PostProcessing/Mover.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/Mover.cs
@@ -1,31 +1,58 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
 namespace CCVTAC.Console.PostProcessing;
 
 internal static class Mover
 {
-    internal static void Run(string workingDirectory, string moveToDirectory, Printer printer)
+    internal static void Run(string workingDirectory, string moveToDirectory, Printer printer, bool shouldOverwrite)
     {
-        uint movedCount = 0;
-        var dir = new DirectoryInfo(workingDirectory);
+        var stopwatch = new System.Diagnostics.Stopwatch();
+        stopwatch.Start();
+
+        uint successCount = 0;
+        uint failureCount = 0;
+        var workingDirInfo = new DirectoryInfo(workingDirectory);
         printer.Print($"Moving audio files to \"{moveToDirectory}\"...");
-        foreach (var file in dir.EnumerateFiles("*.m4a"))
+        foreach (var file in workingDirInfo.EnumerateFiles("*.m4a"))
         {
             try
             {
                 File.Move(
                     file.FullName,
                     $"{Path.Combine(moveToDirectory, file.Name)}",
-                    true);
+                    shouldOverwrite);
+                successCount++;
                 printer.Print($"- Moved \"{file.Name}\"");
-                movedCount++;
             }
             catch (Exception ex)
             {
+                failureCount++;
                 printer.Error($"- Error moving file \"{file.Name}\": {ex.Message}");
             }
         }
-        printer.Print($"{movedCount} file(s) moved.");
+
+        printer.Print($"{successCount} file(s) moved in {stopwatch.ElapsedMilliseconds:#,##0}ms.");
+        printer.Warning($"{failureCount} file(s) could not be moved.");
+
+        WarnAboutOrphanedWorkingFiles(workingDirectory, printer);
+    }
+
+    /// <summary>
+    /// If the working directory contains files when it is expected to be empty,
+    /// then shows a warning message to the user.
+    /// </summary>
+    /// <param name="workingDirectory"></param>
+    /// <param name="printer"></param>
+    private static void WarnAboutOrphanedWorkingFiles(string workingDirectory, Printer printer)
+    {
+        string[] ignoreFiles = new[] { ".DS_Store" }; // Ignore macOS system files
+
+        var files = Directory.GetFiles(workingDirectory, "*")
+                             .Where(dirFile => !ignoreFiles.Any(ignoreFile => dirFile.EndsWith(ignoreFile)));
+
+        if (files.Any())
+        {
+            printer.Warning($"{files.Count()} file(s) unexpectedly remain in the working folder.");
+        }
     }
 }

--- a/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
+++ b/CCVTAC/CCVTAC.Console/PostProcessing/PostProcessing.cs
@@ -1,5 +1,3 @@
-using System.IO;
-
 namespace CCVTAC.Console.PostProcessing;
 
 public class Setup
@@ -8,15 +6,18 @@ public class Setup
     public string MoveToDirectory { get; }
     public Printer Printer { get; }
 
-    public Setup(Settings.Settings setting, Printer printer)
+    public Setup(Settings.Settings settings, Printer printer)
     {
-        WorkingDirectory = setting.WorkingDirectory!;
-        MoveToDirectory = setting.MoveToDirectory!;
+        WorkingDirectory = settings.WorkingDirectory!;
+        MoveToDirectory = settings.MoveToDirectory!;
         Printer = printer;
     }
 
     internal void Run()
     {
+        var stopwatch = new System.Diagnostics.Stopwatch();
+        stopwatch.Start();
+
         Printer.Print("Starting post-processing...");
 
         // TODO: Create an interface and iterate through them, calling `Run()`?
@@ -25,16 +26,8 @@ public class Setup
         // AudioNormalizer.Run(WorkingDirectory, Printer); // TODO: `mp3gain`は無理なので、別のnormalize方法を要検討。
         Renamer.Run(WorkingDirectory, Printer);
         Deleter.Run(WorkingDirectory, Printer);
-        Mover.Run(WorkingDirectory, MoveToDirectory, Printer);
+        Mover.Run(WorkingDirectory, MoveToDirectory, Printer, true);
 
-        IReadOnlyList<string> ignoreFiles = new List<string>() { ".DS_Store" };
-        if (Directory.GetFiles(WorkingDirectory, "*")
-                     .Where(dirFile => !ignoreFiles.Any(ignoreFile => dirFile.EndsWith(ignoreFile)))
-                     .Any())
-        {
-            Printer.Warning("Some files unexpectedly remain in the working folder. Please check it.");
-        }
-
-        Printer.Print("Post-processing done!");
+        Printer.Print($"Post-processing done in {stopwatch.ElapsedMilliseconds:#,##0}ms.");
     }
 }

--- a/CCVTAC/CCVTAC.Console/Program.cs
+++ b/CCVTAC/CCVTAC.Console/Program.cs
@@ -43,21 +43,36 @@ class Program
             version: SettingsService.Id3v2Version.TwoPoint3,
             forceAsDefault: true);
 
+        const string prompt = "Enter a YouTube URL (or 'q' to quit): ";
+        ushort successCount = 0;
+        ushort failureCount = 0;
         while (true)
         {
-            string input = printer.GetInput("Enter a YouTube URL (or 'q' to quit): ");
+            string input = printer.GetInput(prompt);
 
-            if (QuitCommands.Contains(input.ToLowerInvariant())) // TODO: Make case-insensitive.
+            if (QuitCommands.Contains(input.ToLowerInvariant()))
             {
-                printer.Print("Quitting...");
+                var successLabel = successCount == 1 ? "success" : "successes";
+                var failureLabel = failureCount == 1 ? "failure" : "failures";
+                printer.Print($"Quitting with {successCount} {successLabel} and {failureCount} {failureLabel}.");
                 return;
             }
 
-            Run(input, settings, printer);
+            var result = Run(input, settings, printer);
+            if (result.IsSuccess)
+            {
+                successCount++;
+                printer.Print(result.Value, appendLines: 1);
+            }
+            else
+            {
+                failureCount++;
+                printer.Error(result.Value, appendLines: 1);
+            }
         }
     }
 
-    static void Run(string url, Settings.Settings settings, Printer printer)
+    static Result<string> Run(string url, Settings.Settings settings, Printer printer)
     {
         var stopwatch = new System.Diagnostics.Stopwatch();
         stopwatch.Start();
@@ -65,9 +80,8 @@ class Program
         var downloadEntityResult = DownloadEntityFactory.Create(url);
         if (downloadEntityResult.IsFailed)
         {
-            printer.Error(downloadEntityResult.Errors?.First().Message
-                          ?? "An unknown error occurred parsing the resource type.");
-            return;
+            return Result.Fail(downloadEntityResult.Errors?.First().Message
+                               ?? "An unknown error occurred parsing the resource type.");
         }
         var downloadEntity = downloadEntityResult.Value;
         printer.Print($"Processing {downloadEntity.GetType()} URL...");
@@ -77,7 +91,7 @@ class Program
             "--write-thumbnail",
             "--convert-thumbnails jpg",
             "--write-info-json",
-            "--split-chapters"
+            "--split-chapters" // 設定ファイルの項目にするかもしれない。
         };
 
         var downloadResult = ExternalTools.Downloader(
@@ -87,40 +101,40 @@ class Program
             printer);
         if (downloadResult.IsFailed)
         {
-            printer.Error(downloadResult.Errors.First().Message);
-            return;
+            return Result.Fail(downloadResult.Errors.First().Message);
         }
 
-        printer.Print("Adding URL to the history log... ", appendLineBreak: false);
         try
         {
             File.AppendAllText("history.log", url + Environment.NewLine);
+            printer.Print("Added URL to the history log.");
         }
         catch (Exception ex)
         {
-            printer.Error($"Could not append \"{url}\" to history log: " + ex.Message);
+            printer.Error($"Could not append URL {url} to history log: " + ex.Message);
         }
-        printer.Print("OK.");
 
         var postProcessor = new PostProcessing.Setup(settings, printer);
         postProcessor.Run();
 
-        printer.Print($"Done in {stopwatch.ElapsedMilliseconds:#,##0}ms.", appendLines: 1);
+        return Result.Ok($"Done in {stopwatch.ElapsedMilliseconds:#,##0}ms.");
     }
 
     static void PrintHelp(Printer printer)
     {
         printer.Print("CodeConscious Video-to-Audio Converter (ccvtac)");
-        printer.Print("• Converts YouTube videos to M4A audio files saved locally on your device");
-        printer.Print("• Is a wrapper around yt-dlp (https://github.com/yt-dlp/yt-dlp/), which must already be installed");
-        printer.Print("• Adds ID3v2 tags, including video thumbnails as album art and a comment summarizing video metadata");
-        printer.Print("• Keeps a local-only history of entered URLs");
+        printer.Print("- Easily convert YouTube videos to local M4A audio files!");
+        printer.Print("- Supports video and playlist URLs");
+        printer.Print("- Video metadata (uploader name and URL, source URL, etc.) saved to Comment tags");
+        printer.Print("- Renames files via specific regex patterns (to remove resource IDs, etc.)");
+        printer.Print("- Video thumbnails are auto-trimmed and written to files as album art (Optional)");
+        printer.Print("- Post-processed files are automatically moved to a specified directory");
+        printer.Print("- All URLs entered are saved locally to a file named `history.log`", appendLines: 1);
+
         printer.Print("Instructions:");
-        // printer.Print("• When starting the program, optionally supply one or more of the following argument(s):");
-        // printer.Print("    -s   Splits video chapters into separate files (Continues until you quit)");
-        //                     -D   Debug mode, in which no downloads occur
-        printer.Print("• After the application starts, enter single URLs to start the download and conversion process.");
-        printer.Print("  URLs may be for single videos, playlists, or channels.");
+        printer.Print("• Run the program once to generate a blank settings.json file, then populate it with directory paths.");
+        printer.Print("• After the application starts, enter single URLs to start the download process.");
+        printer.Print("  URLs may be for single videos or playlists.");
         printer.Print("• Enter `q` or `quit` to quit.");
     }
 }


### PR DESCRIPTION
- Relocate this code to a more appropriate location where it is guaranteed to be called at the appropriate time for it (i.e., within the `Mover` class).
- Manually specify whether to overwrite existing files when moving
   - This is a bit out of scope, but an easy, safe fix.